### PR TITLE
Upgrade packages before adding bind

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 EXPOSE 53 53/udp
 
-RUN apk --update add bind
+RUN apk --update upgrade && apk add bind
 
 RUN mkdir -m 0755 -p /var/run/named && chown -R root:named /var/run/named
 


### PR DESCRIPTION
A good addition to that line would be ` && rm -rf /var/cache/apk/*` so that the stale indexes don't remain in the built image.