### PR TITLE
Added bind-dnssec-tools

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 EXPOSE 53 53/udp
 
-RUN apk --update upgrade && apk add bind bind-tools bind-plugins
+RUN apk --update upgrade && apk add bind bind-tools bind-plugins bind-dnssec-tools
 
 # /etc/bind needs to be owned by root, group owned by "bind", and chmod 750
 # since we are mounting, do it manually


### PR DESCRIPTION
Sometimes dnssec-keygen needed for the TSIG. Could you accept this pull request and rebuild your docker image, the latest bind for today is bind-9.14.8-r0 in alpine packages? Thanks.