### PR TITLE
Updated for: 9.16.6-r0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-### ISC BIND9 Container (Stable: 9.14.8_xx) built on top of Alpine
-### Last update: 2-6-20
-### Latest Stable Docker Tag: 9.14.8-r5
+### ISC BIND9 Container (Stable: 9.16.6_xx) built on top of Alpine
+### Last update: 30-8-20
+### Latest Stable Docker Tag: 9.16.6-r0
 
 NOTE: "Last Update" is the date of the latest DockerHub build.
 


### PR DESCRIPTION
Fixes #35 and #36

Alpine 3.12 shipped with 9.14.12 and now updated to 9.16.6, so no changes to the Dockerfile are necessary. I tested this build at https://hub.docker.com/r/simonrupf/bind if you'd like to review it.